### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python ReadDict.py"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Twitter: https://twitter.com/PaeTiihau @paetiihau
 
 English dict from: http://www.gwicks.net/dictionaries.htm
 
-
+[![Run on Repl.it](https://repl.it/badge/github/brentsimpson/te-reo-tweets)](https://repl.it/github/brentsimpson/te-reo-tweets)
 
 
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@BrentSimpson/te-reo-tweets).